### PR TITLE
Configuration for the Cytron Maker Nano RP2040

### DIFF
--- a/config/rp2040_klipper_expander.cfg
+++ b/config/rp2040_klipper_expander.cfg
@@ -1,0 +1,62 @@
+# Configuration for the Cytron Maker Nano RP2040
+#
+# This board has two NeoPixels on GPIO11, a beeper on GPIO22 and a bunch of 
+# individually controllable LEDs on GPIO12-15.
+
+[mcu expander]
+serial: /dev/serial/by-id/usb-Klipper_rp2040_XXXXXXXXXXXX-if00
+
+[neopixel expander_leds]
+pin:         expander:gpio11
+chain_count: 2
+color_order: GRB
+
+[output_pin expander_beeper]
+pin:         expander:gpio22
+pwm:         True
+value:       0
+shutdown_value: 0
+cycle_time:  0.001
+
+[temperature_sensor expander]
+sensor_type: temperature_mcu
+sensor_mcu:  expander
+
+[temperature_sensor TH0]
+sensor_pin:  expander:gpio26
+sensor_type: Generic 3950
+
+#[temperature_sensor TH1]
+#sensor_pin:  expander:gpio27
+#sensor_type: Generic 3950
+
+#[temperature_sensor TH2]
+#sensor_pin:  expander:gpio28
+#sensor_type: Generic 3950
+
+#[temperature_sensor TH3]
+#sensor_pin:  expander:gpio29
+#sensor_type: Generic 3950
+
+[fan_generic FAN0]
+pin:         expander:gpio9
+max_power:   1.0
+
+#[fan_generic FAN1]
+#pin:         expander:gpio5
+#max_power:   1.0
+#
+#[fan_generic FAN2]
+#pin:         expander:gpio3
+#max_power:   1.0
+
+[gcode_macro M300]
+gcode:
+  # Use a default 1kHz tone if S is omitted.
+    {% set S = params.S|default(1000)|int %}
+    # Use a 10ms duration is P is omitted.
+    {% set P = params.P|default(100)|int %}
+    SET_PIN PIN=expander_beeper VALUE=0.5 CYCLE_TIME={ 1.0/S if S > 0 else 1 }
+    G4 P{P}
+    SET_PIN PIN=expander_beeper VALUE=0
+


### PR DESCRIPTION
Reference configuration for the Cytron Maker Nano RP2040, for those looking to use a Pi Pico (rev B2) RP2040 micro controller, rather than the Arduino ATMega series.